### PR TITLE
add "ssg" script to path

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "start": "electron electron/main.js",
     "pack": "electron-packager . --overwrite --asar --out=release"
   },
+  "bin": {
+    "ssg": "build.js"
+  },
   "dependencies": {
     "async": "2.6.2",
     "autoprefixer-stylus": "0.14.0",


### PR DESCRIPTION
to be able to use this package via npm, there should be some exported path to be able to use from $PATH:
- https://yarnpkg.com/en/docs/pnp

also, considering https://github.com/entu/ssg/issues/5 perhaps you want to split to two projects:
- cli code for generate
- fullblown electron app (that depends on the npm package)